### PR TITLE
Ticket #6 - Added url tracking between pages and api integration

### DIFF
--- a/frontend/script/url-tracking.js
+++ b/frontend/script/url-tracking.js
@@ -1,37 +1,62 @@
-// getCurrentUrl.js
+import { sendData } from './api-utility.js';
 
-/**
- * Gets the current URL of the website the user is on.
- * @returns {string} The current URL.
- */
-function getCurrentUrl() {
-    return window.location.href;
-  }
-  
+(function () {
   /**
-   * Gets the origin of the current website (protocol + domain).
-   * @returns {string} The origin of the current website.
-   */
-  function getOrigin() {
-    return window.location.origin;
-  }
-  
-  /**
-   * Gets the pathname of the current URL (path after the domain).
-   * @returns {string} The pathname of the current URL.
-   */
-  function getPathname() {
-    return window.location.pathname;
-  }
-  
-  /**
-   * Gets the full URL, origin, and pathname as an object.
+   * Gets the current URL details (full URL, origin, and pathname).
    * @returns {{ fullUrl: string, origin: string, pathname: string }} An object containing URL details.
    */
   function getUrlDetails() {
-    return {
-      fullUrl: getCurrentUrl(),
-      origin: getOrigin(),
-      pathname: getPathname(),
-    };
+      return {
+          fullUrl: window.location.href,
+          origin: window.location.origin,
+          pathname: window.location.pathname,
+      };
   }
+
+
+  /**
+   * Prints the full list of tracked URLs from localStorage for debugging.
+   */
+  function printTrackedUrls() {
+      const storedUrls = JSON.parse(localStorage.getItem('visitedUrls')) || [];
+      console.log("Tracked URLs:", storedUrls);
+  }
+
+  /**
+   * Tracks page transitions and stores/sends the URL details.
+   */
+  function trackPageTransitions() {
+      // Store and send the initial URL details (Page load)
+      const initialUrlDetails = getUrlDetails();
+      //console.log("Page Loaded:", initialUrlDetails); // Log page load
+      sendData("page_visit", {"page_url": initialUrlDetails.fullUrl})
+
+      // Track URL changes using the popstate event (back/forward navigation)
+      window.addEventListener('popstate', function() {
+          const urlDetails = getUrlDetails();
+          //console.log("Back/Forward Navigation Detected:", urlDetails);
+          storeUrlDetails(urlDetails);
+          sendData("page_visit", {"page_url": urlDetails.fullUrl})
+      });
+
+      // Track URL changes when the user clicks on links
+      document.body.addEventListener('click', function(event) {
+          if (event.target.tagName === 'A' && event.target.href) {
+              // Prevent default navigation only for internal links
+              if (new URL(event.target.href).origin === window.location.origin) {
+                  event.preventDefault();
+                  history.pushState({}, '', event.target.href); // Simulate navigation
+                  const urlDetails = getUrlDetails();
+                  //console.log("Internal Link Clicked:", urlDetails);
+                  storeUrlDetails(urlDetails);
+                  sendData("page_visit", {"page_url": urlDetails.fullUrl})
+              } else { //Debugging
+                  //console.log("External Link Clicked - No Tracking:", event.target.href);
+              }
+          }
+      });
+  }
+
+  // Initialize the tracking
+  trackPageTransitions();
+})();


### PR DESCRIPTION
In order to test since we have no links on our page I along with the scripts I also copy and pasted the following snipet directly into the console to create 2 test pages for me to change links between and as desired I saw that it was recording the url properly and storing it as well. 

const link1 = document.createElement('a');
link1.href = '/test-page1';
link1.innerText = 'Go to Test Page 1';
link1.style.display = 'block';

const link2 = document.createElement('a');
link2.href = '/test-page2';
link2.innerText = 'Go to Test Page 2';
link2.style.display = 'block';

document.body.appendChild(link1);
document.body.appendChild(link2);

